### PR TITLE
feat: add block in auth screen

### DIFF
--- a/lib/src/common/widgets/custom_button.dart
+++ b/lib/src/common/widgets/custom_button.dart
@@ -3,7 +3,7 @@ import 'package:flutter/cupertino.dart';
 
 class CupertinoBtn extends StatelessWidget {
   final String label;
-  final VoidCallback onPressed;
+  final VoidCallback? onPressed;
   const CupertinoBtn({Key? key, required this.label, required this.onPressed}) : super(key: key);
 
   @override

--- a/lib/src/router/router.dart
+++ b/lib/src/router/router.dart
@@ -2,6 +2,7 @@ import 'package:first_project01/src/router/routing_const.dart';
 import 'package:first_project01/src/screens/auth/auth_screen.dart';
 import 'package:first_project01/src/screens/auth/bloc/log_in_bloc.dart';
 import 'package:first_project01/src/screens/main_screen/MainScreen.dart';
+import 'package:first_project01/src/screens/register/bloc/registration_bloc.dart';
 import 'package:first_project01/src/screens/register/register_streen.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -19,7 +20,10 @@ class AppRouter {
         );
       case RegisterRoute:
         return CupertinoPageRoute(
-            builder: (context) => RegisterScreen()
+            builder: (context) => BlocProvider(
+              create: (context) => RegistrationBloc(),
+              child: RegisterScreen(),
+            )
         );
       case MainRoute:
         return CupertinoPageRoute(

--- a/lib/src/router/router.dart
+++ b/lib/src/router/router.dart
@@ -1,15 +1,21 @@
 import 'package:first_project01/src/router/routing_const.dart';
 import 'package:first_project01/src/screens/auth/auth_screen.dart';
+import 'package:first_project01/src/screens/auth/bloc/log_in_bloc.dart';
 import 'package:first_project01/src/screens/main_screen/MainScreen.dart';
 import 'package:first_project01/src/screens/register/register_streen.dart';
 import 'package:flutter/cupertino.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 
 class AppRouter {
   static Route generateRoute(RouteSettings routeSettings) {
     switch (routeSettings.name) {
       case AuthRoute:
         return CupertinoPageRoute(
-            builder: (context) => AuthScreen()
+            builder: (context) =>
+                BlocProvider(
+                  create: (context) => LogInBloc(),
+                  child: AuthScreen()
+                )
         );
       case RegisterRoute:
         return CupertinoPageRoute(

--- a/lib/src/screens/auth/auth_screen.dart
+++ b/lib/src/screens/auth/auth_screen.dart
@@ -58,7 +58,8 @@ class _AuthScreenState extends State<AuthScreen> {
                 child: BlocConsumer<LogInBloc, LogInState>(
                   listener: (context, state) {
                     if (state is LogInLoaded) {
-                      Navigator.pushReplacementNamed(context, MainRoute);
+                      Navigator.of(context, rootNavigator: true).pushReplacementNamed(MainRoute);
+                      //Navigator.pushReplacementNamed(context, MainRoute);
                     } else if (state is LogInFailed) {
                       showCupertinoModalPopup(
                           context: context,
@@ -78,7 +79,7 @@ class _AuthScreenState extends State<AuthScreen> {
                   builder: (context, state) {
                     return CupertinoBtn(
                         label: 'Войти',
-                        onPressed: state is LogInLoading ? () {} : () {
+                        onPressed: state is LogInLoading ? null : () {
                           context.read<LogInBloc>().add(
                             LogInPressed(
                               email: emailController.text,

--- a/lib/src/screens/auth/auth_screen.dart
+++ b/lib/src/screens/auth/auth_screen.dart
@@ -93,6 +93,15 @@ class _AuthScreenState extends State<AuthScreen> {
               SizedBox(
                 height: 19,
               ),
+              Padding(
+                  padding: AppPaddings.horizontal,
+                  child: CupertinoBtn(
+                    label: 'Зарегистрироваться',
+                    onPressed: () {
+                      Navigator.pushNamed(context, RegisterRoute);
+                    },
+                  )
+              ),
             ],
           ),
         ));

--- a/lib/src/screens/auth/bloc/log_in_bloc.dart
+++ b/lib/src/screens/auth/bloc/log_in_bloc.dart
@@ -1,0 +1,60 @@
+import 'dart:async';
+
+import 'package:bloc/bloc.dart';
+import 'package:dio/dio.dart';
+import 'package:first_project01/src/common/models/tokens_model.dart';
+import 'package:first_project01/src/common/models/user_model.dart';
+import 'package:hive/hive.dart';
+import 'package:meta/meta.dart';
+
+part 'log_in_event.dart';
+
+part 'log_in_state.dart';
+
+class LogInBloc extends Bloc<LogInEvent, LogInState> {
+  LogInBloc() : super(LogInInitial());
+  final Dio dio = Dio();
+  final Box tokensBox = Hive.box('tokens');
+
+  @override
+  Stream<LogInState> mapEventToState(
+      LogInEvent event,
+      ) async* {
+    yield LogInLoading();
+
+    print('Я работаю и отправляю запрос на сервер!!');
+    if (event is LogInPressed) {
+      try {
+        Response response = await dio.post('http://api.codeunion.kz/api/v1/auth/login',
+            data: {'email': event.email, 'password': event.password});
+        //конвертирование  полей  токена в  созщданную модель
+        TokensModel tokensModel =
+        TokensModel.fromJson(response.data['tokens']);
+
+        //конвертирование  полей  user в  созщданную модель
+        UserModel userInfo = UserModel.fromJson(response.data['user']);
+
+        //запись userInfo в localStorage
+        tokensBox.put('email', userInfo.email);
+        tokensBox.put('nickname', userInfo.nickname);
+
+        //запись токена в localStorage
+        tokensBox.put('access', tokensModel.access);
+        tokensBox.put('refresh', tokensModel.refresh);
+
+        print(tokensBox.get('access'));
+        print(tokensBox.get('refresh'));
+        //Navigator.pushReplacementNamed(context, MainRoute);
+        yield LogInLoaded();
+      } on DioError catch (e) {
+        yield LogInFailed(message: 'Неправильный логин или пароль');
+        throw e;
+      } catch (e) {
+        yield LogInFailed(message: 'Произошла ошибка');
+        throw e;
+      }
+    }
+  }
+
+
+}

--- a/lib/src/screens/auth/bloc/log_in_event.dart
+++ b/lib/src/screens/auth/bloc/log_in_event.dart
@@ -1,0 +1,15 @@
+part of 'log_in_bloc.dart';
+
+@immutable
+abstract class LogInEvent {}
+
+class LogInPressed extends LogInEvent {
+  final String? email;
+  final String? password;
+
+  LogInPressed({
+    required this.email,
+    required this.password
+  });
+
+}

--- a/lib/src/screens/auth/bloc/log_in_state.dart
+++ b/lib/src/screens/auth/bloc/log_in_state.dart
@@ -1,0 +1,16 @@
+part of 'log_in_bloc.dart';
+
+@immutable
+abstract class LogInState {}
+
+class LogInInitial extends LogInState {}
+
+class LogInLoading extends LogInState {}
+
+class LogInLoaded extends LogInState {}
+
+class LogInFailed extends LogInState {
+  final String? message;
+
+  LogInFailed({required this.message});
+}

--- a/lib/src/screens/main_screen/MainScreen.dart
+++ b/lib/src/screens/main_screen/MainScreen.dart
@@ -1,10 +1,14 @@
 import 'package:first_project01/src/common/constants/color_constants.dart';
+import 'package:first_project01/src/router/router.dart';
 import 'package:first_project01/src/screens/auth/auth_screen.dart';
+import 'package:first_project01/src/screens/auth/bloc/log_in_bloc.dart';
 import 'package:first_project01/src/screens/profile/profile_screen.dart';
+import 'package:first_project01/src/screens/register/bloc/registration_bloc.dart';
 import 'package:first_project01/src/screens/register/register_streen.dart';
 import 'package:first_project01/src/screens/ribbon/ribbon_screen.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 
 class MainScreen extends StatelessWidget {
   const MainScreen({Key? key}) : super(key: key);
@@ -68,15 +72,23 @@ class MainScreen extends StatelessWidget {
                 case 0:
                   return RibbonScreen();
                 case 1:
-                  return RegisterScreen();
+                  return BlocProvider(
+                    create: (context) => RegistrationBloc(),
+                    child: RegisterScreen(),
+                  );
                 case 2:
-                  return AuthScreen();
+                  return BlocProvider(
+                    create: (context) => LogInBloc(),
+                    child: AuthScreen(),
+                  );
                 case 3:
                   return ProfileScreen();
                 default:
                   return AuthScreen();
               }
-            });
+            },
+            onGenerateRoute: AppRouter.generateRoute,
+            );
           }),
     );
   }

--- a/lib/src/screens/profile/profile_screen.dart
+++ b/lib/src/screens/profile/profile_screen.dart
@@ -60,13 +60,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
                        //          builder: (context) => MyApp()
                        //      )
                        //  );
-                        Navigator.of(context, rootNavigator: true).pushReplacement(MaterialPageRoute(
-                            builder: (context) => BlocProvider(
-                                create: (context) => LogInBloc(),
-                                child: AuthScreen()
-                            )
-                          )
-                        );
+                        Navigator.of(context, rootNavigator: true).pushReplacementNamed(AuthRoute);
                       },
                       child: Align(
                         alignment: Alignment.centerLeft,

--- a/lib/src/screens/profile/profile_screen.dart
+++ b/lib/src/screens/profile/profile_screen.dart
@@ -1,11 +1,12 @@
 import 'package:first_project01/src/common/constants/color_constants.dart';
 import 'package:first_project01/src/router/routing_const.dart';
 import 'package:first_project01/src/screens/auth/auth_screen.dart';
+import 'package:first_project01/src/screens/auth/bloc/log_in_bloc.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:hive/hive.dart';
-
+import 'package:flutter_bloc/flutter_bloc.dart';
 import '../../../main.dart';
 
 class ProfileScreen extends StatefulWidget {
@@ -60,7 +61,10 @@ class _ProfileScreenState extends State<ProfileScreen> {
                        //      )
                        //  );
                         Navigator.of(context, rootNavigator: true).pushReplacement(MaterialPageRoute(
-                            builder: (context) => AuthScreen()
+                            builder: (context) => BlocProvider(
+                                create: (context) => LogInBloc(),
+                                child: AuthScreen()
+                            )
                           )
                         );
                       },

--- a/lib/src/screens/register/bloc/registration_bloc.dart
+++ b/lib/src/screens/register/bloc/registration_bloc.dart
@@ -1,0 +1,47 @@
+import 'dart:async';
+
+import 'package:bloc/bloc.dart';
+import 'package:dio/dio.dart';
+import 'package:meta/meta.dart';
+
+part 'registration_event.dart';
+part 'registration_state.dart';
+
+class RegistrationBloc extends Bloc<RegistrationEvent, RegistrationState> {
+  RegistrationBloc() : super(RegistrationInitial());
+
+  final Dio dio = Dio();
+
+  @override
+  Stream<RegistrationState> mapEventToState(
+      RegistrationEvent event,
+      ) async* {
+
+    yield RegistrationInLoading();
+
+    if(event is RegistrationInPressed) {
+      print('Я работаю и отправляю запрос на сервер!! - Registration');
+      try {
+        Response response = await dio.post(
+            'http://api.codeunion.kz/api/v1/auth/registration/customer/new',
+            data: {
+              'nickname': event.nickname,
+              'phone': event.phone,
+              'email': event.email,
+              'password': event.password,
+            }
+        );
+
+        yield RegistrationInLoaded();
+
+      } on DioError catch(e) {
+        yield RegistrationInFailed(message: 'Неправильный логин или пароль');
+        throw e;
+      } catch (e) {
+        yield RegistrationInFailed(message: 'Произшла ошибка');
+        throw e;
+      }
+    }
+  }
+
+}

--- a/lib/src/screens/register/bloc/registration_bloc.dart
+++ b/lib/src/screens/register/bloc/registration_bloc.dart
@@ -14,21 +14,21 @@ class RegistrationBloc extends Bloc<RegistrationEvent, RegistrationState> {
 
   @override
   Stream<RegistrationState> mapEventToState(
-      RegistrationEvent event,
+      RegistrationEvent register,
       ) async* {
 
     yield RegistrationInLoading();
 
-    if(event is RegistrationInPressed) {
+    if(register is RegistrationInPressed) {
       print('Я работаю и отправляю запрос на сервер!! - Registration');
       try {
         Response response = await dio.post(
             'http://api.codeunion.kz/api/v1/auth/registration/customer/new',
             data: {
-              'nickname': event.nickname,
-              'phone': event.phone,
-              'email': event.email,
-              'password': event.password,
+              'nickname': register.nickname,
+              'phone': register.phone,
+              'email': register.email,
+              'password': register.password,
             }
         );
 

--- a/lib/src/screens/register/bloc/registration_event.dart
+++ b/lib/src/screens/register/bloc/registration_event.dart
@@ -1,0 +1,18 @@
+part of 'registration_bloc.dart';
+
+@immutable
+abstract class RegistrationEvent {}
+
+class RegistrationInPressed extends RegistrationEvent {
+  final String? nickname;
+  final String? phone;
+  final String? email;
+  final String? password;
+
+  RegistrationInPressed({
+    required this.nickname,
+    required this.phone,
+    required this.email,
+    required this.password,
+   });
+}

--- a/lib/src/screens/register/bloc/registration_state.dart
+++ b/lib/src/screens/register/bloc/registration_state.dart
@@ -1,0 +1,18 @@
+part of 'registration_bloc.dart';
+
+@immutable
+abstract class RegistrationState {}
+
+class RegistrationInitial extends RegistrationState {}
+
+class RegistrationInLoading extends RegistrationState {}
+
+class RegistrationInLoaded extends RegistrationState {}
+
+class RegistrationInFailed extends RegistrationState {
+  final String? message;
+
+  RegistrationInFailed({
+    required this.message
+  });
+}

--- a/lib/src/screens/register/register_streen.dart
+++ b/lib/src/screens/register/register_streen.dart
@@ -102,7 +102,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
                         }
                         return CupertinoBtn(
                           label: 'Создать аккаунт',
-                          onPressed: () async {
+                          onPressed: state is RegistrationInLoading? null : () async {
                             context.read<RegistrationBloc>().add(
                                 RegistrationInPressed(
                                     nickname: loginController.text,

--- a/lib/src/screens/register/register_streen.dart
+++ b/lib/src/screens/register/register_streen.dart
@@ -1,12 +1,25 @@
+import 'package:dio/dio.dart';
 import 'package:first_project01/src/common/constants/color_constants.dart';
 import 'package:first_project01/src/common/widgets/custom_button.dart';
 import 'package:first_project01/src/common/widgets/custom_text_field.dart';
 import 'package:first_project01/src/common/widgets/custom_text_field_divider.dart';
+import 'package:first_project01/src/router/routing_const.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
-class RegisterScreen extends StatelessWidget {
+class RegisterScreen extends StatefulWidget {
   const RegisterScreen({Key? key}) : super(key: key);
+
+  @override
+  State<RegisterScreen> createState() => _RegisterScreenState();
+}
+
+class _RegisterScreenState extends State<RegisterScreen> {
+  Dio dio = Dio();
+  final TextEditingController  loginController = TextEditingController();
+  final TextEditingController phoneController = TextEditingController();
+  final TextEditingController emailController = TextEditingController();
+  final TextEditingController passwordController = TextEditingController();
 
   @override
   Widget build(BuildContext context) {
@@ -35,20 +48,24 @@ class RegisterScreen extends StatelessWidget {
               ),
               CustomTextField(
                 placeholder: 'Логин',
+                controller: loginController,
               ),
               CustomTextFieldDivider(),
               CustomTextField(
                 placeholder: 'Телефон',
+                controller: phoneController,
               ),
               CustomTextFieldDivider(),
               CustomTextField(
                 placeholder: 'Почта',
+                controller: emailController,
               ),
               CustomTextFieldDivider(),
               CustomTextField(
                 placeholder: 'Пароль',
                 showOrHideIconForPassword: true,
                 showOrHideInputType: true,
+                controller: passwordController,
               ),
               Expanded(
                   child: Padding(
@@ -59,7 +76,39 @@ class RegisterScreen extends StatelessWidget {
                     width: double.infinity,
                     child: CupertinoBtn(
                       label: 'Создать аккаунт',
-                      onPressed: () {},
+                      onPressed: () async {
+
+                        try{
+                          Response response = await dio.post(
+                              'http://api.codeunion.kz/api/v1/auth/registration/customer/new',
+                            data: {
+                                'nickname': loginController.text,
+                                'phone': phoneController.text,
+                                'email': emailController.text,
+                                'password': passwordController.text,
+                              }
+                          );
+                          Navigator.pushReplacementNamed(context, AuthRoute);
+                        } on DioError catch (e) {
+                          print(e.response!.data);
+                          showCupertinoModalPopup(
+                             context: context,
+                              builder: (context) {
+                                return CupertinoAlertDialog(
+                                  title: Text('Ошибка'),
+                                  content: Text('Неправильно веденные  данные \n'
+                                      '${e.response!.data['message']}'),
+                                  actions: [
+                                    CupertinoButton(
+                                        child: Text('Ок'),
+                                        onPressed: () => Navigator.pop(context)
+                                    )
+                                  ],
+                                );
+                              }
+                         );
+                        }
+                      },
                     ),
                   ),
                 ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -53,6 +53,7 @@ dev_dependencies:
   flutter_lints: ^1.0.0
   build_runner: ^2.1.7
   json_serializable: ^6.1.4
+  flutter_bloc: ^7.2.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
Все по заданиям раздела Bloc и  Вашим исправлениям сделал!
Но, есть баг, когда выхожу с  личного кабинета и когда в bottomNavBar перехожу  на Auth или Registr - крашится. Нужна подсказка, как  решить), ругается  на Bloc
1. ошибка по ссылке: https://d.radikal.ru/d22/2202/99/8fd0236c8623.jpg
2. Ошибка  выше вылетает, когда выходишь из аккаунта - https://d.radikal.ru/d01/2202/77/d272cbb356f0.jpg
3.  Еще в рамках BottomNavBar - с ошибками отображаются  страницы, которые в  Bloc обернуты, выглядит вот так - https://a.radikal.ru/a17/2202/4f/4b58a26f482f.jpg
Что то пока не нагуглил решение я.

Вылетает ошибка: "
Error: Could not find the correct Provider<LogInBloc> above this BlocConsumer<LogInBloc, LogInState> Widget

This happens because you used a `BuildContext` that does not include the provider
of your choice. There are a few common scenarios:

- You added a new provider in your `main.dart` and performed a hot-reload.
  To fix, perform a hot-restart.

"